### PR TITLE
Improve behind the scene design pattern for chaining

### DIFF
--- a/Async.swift
+++ b/Async.swift
@@ -75,7 +75,7 @@ extension Async { // Static methods
 	/* dispatch_async() */
 
 	private static func async(block: dispatch_block_t, inQueue queue: dispatch_queue_t) -> Async {
-		// Create a new block (Qos Class) from block to allow adding a notification to it later (see Async)
+		// Create a new block (Qos Class) from block to allow adding a notification to it later (see matching regular Async methods)
 		// Create block with the "inherit" type
 		let _block = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, block)
 		// Add block to queue


### PR DESCRIPTION
The new heart of Async:

``` swift
public struct Async {

    private let block: dispatch_block_t

    private init(_ block: dispatch_block_t) {
        self.block = block
    }
}


extension Async { // Static methods

    private static func async(block: dispatch_block_t, inQueue queue: dispatch_queue_t) -> Async {
        // Create a new block (Qos Class) from block to allow adding a notification to it later (see Async)
        // Create block with the "inherit" type
        let _block = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, block)
        // Add block to queue
        dispatch_async(queue, _block)
        // Wrap block in a struct since dispatch_block_t can't be extended
        return Async(_block)
    }

    static func main(block: dispatch_block_t) -> Async {
        return Async.async(block, inQueue: GCD.mainQueue())
    }
}


extension Async { // Regualar methods matching static once

    private func chain(block chainingBlock: dispatch_block_t, runInQueue queue: dispatch_queue_t) -> Async {
        // See Async.async() for comments
        let _chainingBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, chainingBlock)
        dispatch_block_notify(self.block, queue, _chainingBlock)
        return Async(_chainingBlock)
    }

    func main(chainingBlock: dispatch_block_t) -> Async {
        return chain(block: chainingBlock, runInQueue: GCD.mainQueue())
    }
}
```
