### PR TITLE
Adding dynamic framework target for Async

### DIFF
--- a/Async.swift
+++ b/Async.swift
@@ -72,7 +72,7 @@ public struct Async {
 }
 
 
-extension Async { // Static methods
+public extension Async { // Static methods
 
 	
 	/* dispatch_async() */
@@ -146,7 +146,7 @@ extension Async { // Static methods
 }
 
 
-extension Async { // Regualar methods matching static once
+public extension Async { // Regualar methods matching static once
 
 
 	/* dispatch_async() */
@@ -250,7 +250,7 @@ extension Async { // Regualar methods matching static once
 
 
 // Convenience
-extension qos_class_t {
+public extension qos_class_t {
 
 	// Calculated property
 	var description: String {

--- a/Async/Async.xcodeproj/project.pbxproj
+++ b/Async/Async.xcodeproj/project.pbxproj
@@ -1,0 +1,414 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		90B86A911A3259F4000266D6 /* Async.h in Headers */ = {isa = PBXBuildFile; fileRef = 90B86A901A3259F4000266D6 /* Async.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		90B86A971A3259F4000266D6 /* Async.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90B86A8B1A3259F4000266D6 /* Async.framework */; };
+		90B86A9E1A3259F4000266D6 /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B86A9D1A3259F4000266D6 /* AsyncTests.swift */; };
+		90B86AA81A325A31000266D6 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B86AA71A325A31000266D6 /* Async.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		90B86A981A3259F4000266D6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B86A821A3259F4000266D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 90B86A8A1A3259F4000266D6;
+			remoteInfo = Async;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		90B86A8B1A3259F4000266D6 /* Async.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Async.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		90B86A8F1A3259F4000266D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90B86A901A3259F4000266D6 /* Async.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Async.h; sourceTree = "<group>"; };
+		90B86A961A3259F4000266D6 /* AsyncTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AsyncTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		90B86A9C1A3259F4000266D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90B86A9D1A3259F4000266D6 /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
+		90B86AA71A325A31000266D6 /* Async.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Async.swift; path = ../../Async.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		90B86A871A3259F4000266D6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90B86A931A3259F4000266D6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90B86A971A3259F4000266D6 /* Async.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		90B86A811A3259F4000266D6 = {
+			isa = PBXGroup;
+			children = (
+				90B86A8D1A3259F4000266D6 /* Async */,
+				90B86A9A1A3259F4000266D6 /* AsyncTests */,
+				90B86A8C1A3259F4000266D6 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		90B86A8C1A3259F4000266D6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				90B86A8B1A3259F4000266D6 /* Async.framework */,
+				90B86A961A3259F4000266D6 /* AsyncTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		90B86A8D1A3259F4000266D6 /* Async */ = {
+			isa = PBXGroup;
+			children = (
+				90B86A901A3259F4000266D6 /* Async.h */,
+				90B86AA71A325A31000266D6 /* Async.swift */,
+				90B86A8E1A3259F4000266D6 /* Supporting Files */,
+			);
+			path = Async;
+			sourceTree = "<group>";
+		};
+		90B86A8E1A3259F4000266D6 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				90B86A8F1A3259F4000266D6 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		90B86A9A1A3259F4000266D6 /* AsyncTests */ = {
+			isa = PBXGroup;
+			children = (
+				90B86A9D1A3259F4000266D6 /* AsyncTests.swift */,
+				90B86A9B1A3259F4000266D6 /* Supporting Files */,
+			);
+			path = AsyncTests;
+			sourceTree = "<group>";
+		};
+		90B86A9B1A3259F4000266D6 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				90B86A9C1A3259F4000266D6 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		90B86A881A3259F4000266D6 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90B86A911A3259F4000266D6 /* Async.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		90B86A8A1A3259F4000266D6 /* Async */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 90B86AA11A3259F4000266D6 /* Build configuration list for PBXNativeTarget "Async" */;
+			buildPhases = (
+				90B86A861A3259F4000266D6 /* Sources */,
+				90B86A871A3259F4000266D6 /* Frameworks */,
+				90B86A881A3259F4000266D6 /* Headers */,
+				90B86A891A3259F4000266D6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Async;
+			productName = Async;
+			productReference = 90B86A8B1A3259F4000266D6 /* Async.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		90B86A951A3259F4000266D6 /* AsyncTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 90B86AA41A3259F4000266D6 /* Build configuration list for PBXNativeTarget "AsyncTests" */;
+			buildPhases = (
+				90B86A921A3259F4000266D6 /* Sources */,
+				90B86A931A3259F4000266D6 /* Frameworks */,
+				90B86A941A3259F4000266D6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				90B86A991A3259F4000266D6 /* PBXTargetDependency */,
+			);
+			name = AsyncTests;
+			productName = AsyncTests;
+			productReference = 90B86A961A3259F4000266D6 /* AsyncTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		90B86A821A3259F4000266D6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = dk.developmunk;
+				TargetAttributes = {
+					90B86A8A1A3259F4000266D6 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+					90B86A951A3259F4000266D6 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 90B86A851A3259F4000266D6 /* Build configuration list for PBXProject "Async" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 90B86A811A3259F4000266D6;
+			productRefGroup = 90B86A8C1A3259F4000266D6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				90B86A8A1A3259F4000266D6 /* Async */,
+				90B86A951A3259F4000266D6 /* AsyncTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		90B86A891A3259F4000266D6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90B86A941A3259F4000266D6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		90B86A861A3259F4000266D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90B86AA81A325A31000266D6 /* Async.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90B86A921A3259F4000266D6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90B86A9E1A3259F4000266D6 /* AsyncTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		90B86A991A3259F4000266D6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 90B86A8A1A3259F4000266D6 /* Async */;
+			targetProxy = 90B86A981A3259F4000266D6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		90B86A9F1A3259F4000266D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		90B86AA01A3259F4000266D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		90B86AA21A3259F4000266D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Async/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		90B86AA31A3259F4000266D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Async/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		90B86AA51A3259F4000266D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AsyncTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		90B86AA61A3259F4000266D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = AsyncTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		90B86A851A3259F4000266D6 /* Build configuration list for PBXProject "Async" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90B86A9F1A3259F4000266D6 /* Debug */,
+				90B86AA01A3259F4000266D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		90B86AA11A3259F4000266D6 /* Build configuration list for PBXNativeTarget "Async" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90B86AA21A3259F4000266D6 /* Debug */,
+				90B86AA31A3259F4000266D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		90B86AA41A3259F4000266D6 /* Build configuration list for PBXNativeTarget "AsyncTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				90B86AA51A3259F4000266D6 /* Debug */,
+				90B86AA61A3259F4000266D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 90B86A821A3259F4000266D6 /* Project object */;
+}

--- a/Async/Async.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Async/Async.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Async.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Async/Async/Async.h
+++ b/Async/Async/Async.h
@@ -1,0 +1,19 @@
+//
+//  Async.h
+//  Async
+//
+//  Created by mike.owens on 12/5/14.
+//  Copyright (c) 2014 dk.developmunk. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Async.
+FOUNDATION_EXPORT double AsyncVersionNumber;
+
+//! Project version string for Async.
+FOUNDATION_EXPORT const unsigned char AsyncVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Async/PublicHeader.h>
+
+

--- a/Async/Async/Info.plist
+++ b/Async/Async/Info.plist
@@ -5,28 +5,22 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>dk.developmunk.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Async/AsyncTests/AsyncTests.swift
+++ b/Async/AsyncTests/AsyncTests.swift
@@ -1,0 +1,438 @@
+//
+//  AsyncTests.swift
+//  AsyncTests
+//
+//  Created by Tobias DM on 15/07/14.
+//  Copyright (c) 2014 Tobias Due Munk. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Async
+
+class AsyncTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    
+    /* GCD */
+    
+    func testGCD() {
+        
+        let expectation = expectationWithDescription("Expected after time")
+        
+        let qos = QOS_CLASS_BACKGROUND
+        let queue = dispatch_get_global_queue(qos.id, 0)
+        dispatch_async(queue) {
+            let currentQos = qos_class_self()
+            XCTAssertEqual(currentQos.id, qos.id, "On \(currentQos.description) (expected \(qos.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    
+    /* dispatch_async() */
+    
+    func testAsyncMain() {
+        let expectation = expectationWithDescription("Expected on main queue")
+        var calledStuffAfterSinceAsync = false
+        Async.main {
+            XCTAssertEqual(qos_class_self().id, qos_class_main().id, "On \(qos_class_self().description) (expexted \(qos_class_main().description))")
+            XCTAssert(calledStuffAfterSinceAsync, "Should be async")
+            expectation.fulfill()
+        }
+        calledStuffAfterSinceAsync = true
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testAsyncUserInteractive() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+        Async.userInteractive {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INTERACTIVE.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testAsyncUserInitiared() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INITIATED.description))")
+        Async.userInitiated {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INITIATED.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INITIATED.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    // Not expected to succeed (Apples wording: "Not intended as a work classification")
+    func testAsyncDefault() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_DEFAULT.description))")
+        Async.default_ {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_DEFAULT.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_DEFAULT.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testAsyncUtility() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+        Async.utility {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_UTILITY.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_UTILITY.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testAsyncBackground() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+        Async.background {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testAsyncBackgroundToMain() {
+        let expectation = expectationWithDescription("Expected on background to main queue")
+        var wasInBackground = false
+        Async.background {
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            wasInBackground = true
+            }.main {
+                XCTAssertEqual(qos_class_self().id, qos_class_main().id, "On \(qos_class_self().description) (expected \(qos_class_main().description))")
+                XCTAssert(wasInBackground, "Was in background first")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testChaining() {
+        let expectation = expectationWithDescription("Expected On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+        var id = 0
+        Async.main {
+            XCTAssertEqual(qos_class_self().id, qos_class_main().id, "On \(qos_class_self().description) (expexted \(qos_class_main().description))")
+            XCTAssertEqual(++id, 1, "Count main queue")
+            }.userInteractive {
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INTERACTIVE.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+                XCTAssertEqual(++id, 2, "Count user interactive queue")
+            }.userInitiated {
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INITIATED.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INITIATED.description))")
+                XCTAssertEqual(++id, 3, "Count user initiated queue")
+            }.utility {
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_UTILITY.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_UTILITY.description))")
+                XCTAssertEqual(++id, 4, "Count utility queue")
+            }.background {
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+                XCTAssertEqual(++id, 5, "Count background queue")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    func testCustomQueue() {
+        let expectation = expectationWithDescription("Expected custom queues")
+        var id = 0
+        let customQueue = dispatch_queue_create("CustomQueueLabel", DISPATCH_QUEUE_CONCURRENT)
+        let otherCustomQueue = dispatch_queue_create("OtherCustomQueueLabel", DISPATCH_QUEUE_SERIAL)
+        Async.customQueue(customQueue) {
+            XCTAssertEqual(++id, 1, "Count custom queue")
+            }.customQueue(otherCustomQueue) {
+                XCTAssertEqual(++id, 2, "Count other custom queue")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+    
+    
+    /* dispatch_after() */
+    
+    func testAfterGCD() {
+        
+        let expectation = expectationWithDescription("Expected after time")
+        let date = NSDate()
+        let timeDelay = 1.0
+        let upperTimeDelay = timeDelay + 0.2
+        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(timeDelay * Double(NSEC_PER_SEC)))
+        let queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND.id, 0)
+        dispatch_after(time, queue, {
+            let timePassed = NSDate().timeIntervalSinceDate(date)
+            println("\(timePassed)")
+            XCTAssert(timePassed >= timeDelay, "Should wait \(timeDelay) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay, "Shouldn't wait \(upperTimeDelay) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            expectation.fulfill()
+        })
+        waitForExpectationsWithTimeout(timeDelay*2, handler: nil)
+    }
+    
+    func testAfterMain() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date = NSDate()
+        let timeDelay = 1.0
+        let upperTimeDelay = timeDelay + 0.2
+        Async.main(after: timeDelay) {
+            let timePassed = NSDate().timeIntervalSinceDate(date)
+            XCTAssert(timePassed >= timeDelay, "Should wait \(timeDelay) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay, "Shouldn't wait \(upperTimeDelay) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, qos_class_main().id, "On main queue")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(timeDelay*2, handler: nil)
+    }
+    
+    func testChainedAfter() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.userInteractive(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INTERACTIVE.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+            
+            date2 = NSDate() // Update
+            }.utility(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_UTILITY.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_UTILITY.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    func testAfterUserInteractive() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.userInteractive(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INTERACTIVE.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+            
+            date2 = NSDate() // Update
+            }.userInteractive(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INTERACTIVE.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INTERACTIVE.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    func testAfterUserInitiated() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.userInitiated(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INITIATED.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INITIATED.description))")
+            
+            date2 = NSDate() // Update
+            }.userInitiated(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_USER_INITIATED.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_USER_INITIATED.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    // Not expected to succeed (Apples wording: "Not intended as a work classification")
+    func testAfterUserDefault() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.default_(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_DEFAULT.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_DEFAULT.description))")
+            
+            date2 = NSDate() // Update
+            }.default_(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_DEFAULT.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_DEFAULT.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    func testAfterUtility() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.utility(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_UTILITY.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_UTILITY.description))")
+            
+            date2 = NSDate() // Update
+            }.utility(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_UTILITY.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_UTILITY.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    func testAfterBackground() {
+        let expectation = expectationWithDescription("Expected after time")
+        let date1 = NSDate()
+        var date2 = NSDate()
+        let timeDelay1 = 1.1
+        let upperTimeDelay1 = timeDelay1 + 0.2
+        let timeDelay2 = 1.2
+        let upperTimeDelay2 = timeDelay2 + 0.2
+        var id = 0
+        Async.background(after: timeDelay1) {
+            XCTAssertEqual(++id, 1, "First after")
+            
+            let timePassed = NSDate().timeIntervalSinceDate(date1)
+            XCTAssert(timePassed >= timeDelay1, "Should wait \(timeDelay1) seconds before firing")
+            XCTAssert(timePassed < upperTimeDelay1, "Shouldn't wait \(upperTimeDelay1) seconds before firing")
+            XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            
+            date2 = NSDate() // Update
+            }.background(after: timeDelay2) {
+                XCTAssertEqual(++id, 2, "Second after")
+                
+                let timePassed = NSDate().timeIntervalSinceDate(date2)
+                XCTAssert(timePassed >= timeDelay2, "Should wait \(timeDelay2) seconds before firing")
+                XCTAssert(timePassed < upperTimeDelay2, "Shouldn't wait \(upperTimeDelay2) seconds before firing")
+                XCTAssertEqual(qos_class_self().id, QOS_CLASS_BACKGROUND.id, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+                expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout((timeDelay1 + timeDelay2) * 2, handler: nil)
+    }
+    
+    
+    /* dispatch_block_cancel() */
+    
+    func testCancel() {
+        let expectation = expectationWithDescription("Block1 should run")
+        
+        let block1 = Async.background {
+            // Heavy work
+            for i in 0...1000 {
+                println("A \(i)")
+            }
+            expectation.fulfill()
+        }
+        let block2 = block1.background {
+            println("B – shouldn't be reached, since cancelled")
+            XCTFail("Shouldn't be reached, since cancelled")
+        }
+        
+        Async.main(after: 0.01) {
+            block1.cancel() // First block is _not_ cancelled
+            block2.cancel() // Second block _is_ cancelled
+        }
+        
+        waitForExpectationsWithTimeout(20, handler: nil)
+    }
+    
+    
+    /* dispatch_wait() */
+    
+    func testWait() {
+        var id = 0
+        let block = Async.background {
+            // Heavy work
+            for i in 0...100 {
+                println("A \(i)")
+            }
+            XCTAssertEqual(++id, 1, "")
+        }
+        XCTAssertEqual(id, 0, "")
+        
+        block.wait()
+        XCTAssertEqual(++id, 2, "")
+    }
+    
+    func testWaitMax() {
+        var id = 0
+        let block = Async.background {
+            XCTAssertEqual(++id, 1, "") // A
+            // Heavy work
+            for i in 0...10000 {
+                println("A \(i)")
+            }
+            XCTAssertEqual(++id, 3, "") // C
+        }
+        XCTAssertEqual(id, 0, "")
+        
+        let date = NSDate()
+        let timeDelay = 0.3
+        let upperTimeDelay = timeDelay + 0.2
+        
+        block.wait(seconds: timeDelay)
+        
+        XCTAssertEqual(++id, 2, "") // B
+        let timePassed = NSDate().timeIntervalSinceDate(date)
+        XCTAssert(timePassed < upperTimeDelay, "Shouldn't wait \(upperTimeDelay) seconds before firing")
+    }
+}

--- a/Async/AsyncTests/Info.plist
+++ b/Async/AsyncTests/Info.plist
@@ -5,28 +5,20 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>${EXECUTABLE_NAME}</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>dk.developmunk.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Adding a dynamic framework target for better linking into swift projects. 

Now that iOS8 supports dynamic frameworks, this is the ideal way to link in Swift projects. This is not yet supported by Cocoapods, however a [PR](https://github.com/CocoaPods/CocoaPods/pull/2835) for Swift frameworks exists.

The following adds:
- a new xCode project with framework target for iOS
- exposes Async interface to framework
- Adds iOS unit tests to the framework target tests (however these are currently broken both in the framework and the iOS app example)

To dynamic link against the new framework, follow the [instructions here](https://github.com/Alamofire/Alamofire#installation), but reference to Async.framework instead