### PR TITLE
Add AsyncGroup struct to handle execution of groups of multiple dispatch blocks.

### DIFF
--- a/AsyncTest/Async.xcodeproj/project.pbxproj
+++ b/AsyncTest/Async.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		4EE7A27E1BDE467100C957BA /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE7A2511BDE41B600C957BA /* AsyncTests.swift */; };
 		4EE7A27F1BDE468E00C957BA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE7A24F1BDE418400C957BA /* Async.swift */; };
 		4EE7A2801BDE468F00C957BA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE7A24F1BDE418400C957BA /* Async.swift */; };
+		9524933A1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952493391C61C3A500EEF97A /* AsyncGroupTests.swift */; };
+		9524933B1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952493391C61C3A500EEF97A /* AsyncGroupTests.swift */; };
+		9524933C1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952493391C61C3A500EEF97A /* AsyncGroupTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +84,7 @@
 		4EE7A2511BDE41B600C957BA /* AsyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
 		4EE7A25E1BDE466A00C957BA /* AsynciOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AsynciOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EE7A2711BDE466A00C957BA /* AsynciOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AsynciOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		952493391C61C3A500EEF97A /* AsyncGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncGroupTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +158,7 @@
 			children = (
 				4EE7A24F1BDE418400C957BA /* Async.swift */,
 				4EE7A2511BDE41B600C957BA /* AsyncTests.swift */,
+				952493391C61C3A500EEF97A /* AsyncGroupTests.swift */,
 				4EE7A20F1BDE415200C957BA /* AsynciOS */,
 				4EE7A2241BDE415200C957BA /* AsynciOSTests */,
 				4EE7A2351BDE417600C957BA /* AsyncOSX */,
@@ -449,6 +454,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4EC98A651BE02E6700A2EB40 /* AsyncTests.swift in Sources */,
+				9524933C1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */,
 				4EC98A671BE02E6B00A2EB40 /* Async.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -467,6 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4EE7A2591BDE42D700C957BA /* Async.swift in Sources */,
+				9524933A1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */,
 				4EE7A2531BDE41B600C957BA /* AsyncTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -486,6 +493,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4EE7A27E1BDE467100C957BA /* AsyncTests.swift in Sources */,
+				9524933B1C61C3A500EEF97A /* AsyncGroupTests.swift in Sources */,
 				4EE7A2801BDE468F00C957BA /* Async.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AsyncTest/AsyncGroupTests.swift
+++ b/AsyncTest/AsyncGroupTests.swift
@@ -1,0 +1,85 @@
+//
+//  AsyncGroupTests.swift
+//  Async
+//
+//  Created by Eneko Alonso on 2/2/16.
+//  Copyright © 2016 developmunk. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+class AsyncGroupTests: XCTestCase {
+
+    // Typical testing time delay. Must be bigger than `timeMargin`
+    let timeDelay = 0.3
+    // Allowed error for timeDelay
+    let timeMargin = 0.2
+
+    func testBackgroundGroup() {
+        let expectation = expectationWithDescription("Expected on background queue")
+        let group = AsyncGroup()
+        group.background {
+            XCTAssertEqual(qos_class_self(), QOS_CLASS_BACKGROUND, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(timeMargin, handler: nil)
+    }
+
+    func testGroupWait() {
+        var complete = false
+        let group = AsyncGroup()
+        group.background {
+            XCTAssertEqual(qos_class_self(), QOS_CLASS_BACKGROUND, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            complete = true
+        }
+        group.wait(seconds: timeMargin)
+        XCTAssertEqual(complete, true)
+    }
+
+    func testMultipleGroups() {
+        var count = 0
+        let group = AsyncGroup()
+        for _ in 1...10 {
+            group.background {
+                XCTAssertEqual(qos_class_self(), QOS_CLASS_BACKGROUND, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+                count++
+            }
+        }
+        group.wait(seconds: timeMargin)
+        XCTAssertEqual(count, 10)
+    }
+
+    func testCustomBlockGroups() {
+        var count = 0
+        let group = AsyncGroup()
+        for _ in 1...10 {
+            group.enter()
+            Async.background {
+                XCTAssertEqual(qos_class_self(), QOS_CLASS_BACKGROUND, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+                count++
+                group.leave()
+            }
+        }
+        group.wait(seconds: timeMargin)
+        XCTAssertEqual(count, 10)
+    }
+
+    func testNestedAsyncGroups() {
+        var count = 0
+        let group = AsyncGroup()
+        for _ in 1...10 {
+            group.background {
+                XCTAssertEqual(qos_class_self(), QOS_CLASS_BACKGROUND, "On \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+                group.enter()
+                Async.background {
+                    count++
+                    group.leave()
+                }
+            }
+        }
+        group.wait(seconds: timeMargin)
+        XCTAssertEqual(count, 10)
+    }
+
+}

--- a/AsyncTest/AsyncTests.swift
+++ b/AsyncTest/AsyncTests.swift
@@ -574,4 +574,5 @@ class AsyncTests: XCTestCase {
         assert(count == 3, "Wrong count")
         waitForExpectationsWithTimeout(1, handler: nil)
     }
+
 }

--- a/Source/Async.swift
+++ b/Source/Async.swift
@@ -35,7 +35,7 @@ import Foundation
 /**
 `GCD` is an empty struct with convenience static functions to get `dispatch_queue_t` of different quality of service classes, as provided by `dispatch_get_global_queue`.
 
-    let utilityQueue = GCD.utilityQueue()
+let utilityQueue = GCD.utilityQueue()
 
 - SeeAlso: Grand Central Dispatch
 */
@@ -59,9 +59,9 @@ private struct GCD {
      Returns a system-defined global concurrent queue with the specified quality of service class.
 
      - Returns: The global concurrent queue with quality of service class QOS_CLASS_USER_INTERACTIVE.
-     
+
      - SeeAlso: dispatch_get_global_queue
-    */
+     */
     static func userInteractiveQueue() -> dispatch_queue_t {
         return dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)
     }
@@ -107,60 +107,60 @@ private struct GCD {
 // MARK: - Async – Struct
 
 /**
-    The **Async** struct is the main part of the Async.framework. Handles a internally `dispatch_block_t`.
+The **Async** struct is the main part of the Async.framework. Handles a internally `dispatch_block_t`.
 
-    Chainable dispatch blocks with GCD:
+Chainable dispatch blocks with GCD:
 
-        Async.background {
-            // Run on background queue
-        }.main {
-            // Run on main queue, after the previous block
-        }
+Async.background {
+// Run on background queue
+}.main {
+// Run on main queue, after the previous block
+}
 
-    All moderns queue classes:
-    
-        Async.main {}
-        Async.userInteractive {}
-        Async.userInitiated {}
-        Async.utility {}
-        Async.background {}
+All moderns queue classes:
 
-    Custom queues:
+Async.main {}
+Async.userInteractive {}
+Async.userInitiated {}
+Async.utility {}
+Async.background {}
 
-        let customQueue = dispatch_queue_create("Label",
-            DISPATCH_QUEUE_CONCURRENT)
-        Async.customQueue(customQueue) {}
+Custom queues:
 
-    Dispatch block after delay:
+let customQueue = dispatch_queue_create("Label",
+DISPATCH_QUEUE_CONCURRENT)
+Async.customQueue(customQueue) {}
 
-        let seconds = 0.5
-        Async.main(after: seconds) {}
+Dispatch block after delay:
 
-    Cancel blocks not yet dispatched
+let seconds = 0.5
+Async.main(after: seconds) {}
 
-        let block1 = Async.background {
-            // Some work
-        }
-        let block2 = block1.background {
-            // Some other work
-        }
-        Async.main {
-            // Cancel async to allow block1 to begin
-            block1.cancel() // First block is NOT cancelled
-            block2.cancel() // Second block IS cancelled
-        }
+Cancel blocks not yet dispatched
 
-    Wait for block to finish:
+let block1 = Async.background {
+// Some work
+}
+let block2 = block1.background {
+// Some other work
+}
+Async.main {
+// Cancel async to allow block1 to begin
+block1.cancel() // First block is NOT cancelled
+block2.cancel() // Second block IS cancelled
+}
 
-        let block = Async.background {
-            // Do stuff
-        }
-        // Do other stuff
-        // Wait for "Do stuff" to finish
-        block.wait()
-        // Do rest of stuff
+Wait for block to finish:
 
-    - SeeAlso: Grand Central Dispatch
+let block = Async.background {
+// Do stuff
+}
+// Do other stuff
+// Wait for "Do stuff" to finish
+block.wait()
+// Do rest of stuff
+
+- SeeAlso: Grand Central Dispatch
 */
 public struct Async {
 
@@ -174,7 +174,7 @@ public struct Async {
 
     /**
      Private init that takes a `dispatch_block_t`
-    */
+     */
     private init(_ block: dispatch_block_t) {
         self.block = block
     }
@@ -186,11 +186,11 @@ public struct Async {
     Sends the a block to be run asynchronously on the main thread.
 
     - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the main queue
+    - after: After how many seconds the block should be run.
+    - block: The block that is to be passed to be run on the main queue
 
-        - returns: An `Async` struct
-    
+    - returns: An `Async` struct
+
     - SeeAlso: Has parity with non-static method
     */
     public static func main(after after: Double? = nil, block: dispatch_block_t) -> Async {
@@ -201,8 +201,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -216,8 +216,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -231,8 +231,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_UTILITY.
 
      - parameters:
-         - after: After how many seconds the block should be run.
-         - block: The block that is to be passed to be run on queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on queue
 
      - returns: An `Async` struct
 
@@ -246,8 +246,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND.
 
      - parameters:
-         - after: After how many seconds the block should be run.
-         - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -261,8 +261,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a custom queue.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -277,11 +277,11 @@ public struct Async {
 
     /**
     Convenience for `asyncNow()` or `asyncAfter()` depending on if the parameter `seconds` is passed or nil.
-    
+
     - parameters:
-        - seconds: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
+    - seconds: After how many seconds the block should be run.
+    - block: The block that is to be passed to be run on the `queue`
+    - queue: The queue on which the `block` is run.
 
     - returns: An `Async` struct which encapsulates the `dispatch_block_t`
     */
@@ -294,10 +294,10 @@ public struct Async {
 
     /**
      Convenience for dispatch_async(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
-     
+
      - parameters:
-         - block: The block that is to be passed to be run on the `queue`
-         - queue: The queue on which the `block` is run.
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`
      */
@@ -313,14 +313,14 @@ public struct Async {
 
     /**
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
-     
-     - parameters:
-        - seconds: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
 
-    - returns: An `Async` struct which encapsulates the `dispatch_block_t`
-    */
+     - parameters:
+     - seconds: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
+
+     - returns: An `Async` struct which encapsulates the `dispatch_block_t`
+     */
     private static func asyncAfter(seconds: Double, block: dispatch_block_t, queue: dispatch_queue_t) -> Async {
         let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
         let time = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
@@ -331,9 +331,9 @@ public struct Async {
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-        - time: The specific time (`dispatch_time_t`) the block should be run.
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
+     - time: The specific time (`dispatch_time_t`) the block should be run.
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`
      */
@@ -351,8 +351,8 @@ public struct Async {
     Sends the a block to be run asynchronously on the main thread, after the current block has finished.
 
     - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the main queue
+    - after: After how many seconds the block should be run.
+    - block: The block that is to be passed to be run on the main queue
 
     - returns: An `Async` struct
 
@@ -366,8 +366,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE, after the current block has finished.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -381,8 +381,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED, after the current block has finished.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -396,8 +396,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_UTILITY, after the current block has finished.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -411,8 +411,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND, after the current block has finished.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -426,8 +426,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a custom queue, after the current block has finished.
 
      - parameters:
-        - after: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the queue
+     - after: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -440,24 +440,24 @@ public struct Async {
     // MARK: - Instance methods
 
     /**
-     Convenience function to call `dispatch_block_cancel()` on the encapsulated block.
-     Cancels the current block, if it hasn't already begun running to GCD.
-     
-     Usage: 
+    Convenience function to call `dispatch_block_cancel()` on the encapsulated block.
+    Cancels the current block, if it hasn't already begun running to GCD.
 
-        let block1 = Async.background {
-            // Some work
-        }
-        let block2 = block1.background {
-            // Some other work
-        }
-        Async.main {
-            // Cancel async to allow block1 to begin
-            block1.cancel() // First block is NOT cancelled
-            block2.cancel() // Second block IS cancelled
-        }
+    Usage:
 
-     */
+    let block1 = Async.background {
+    // Some work
+    }
+    let block2 = block1.background {
+    // Some other work
+    }
+    Async.main {
+    // Cancel async to allow block1 to begin
+    block1.cancel() // First block is NOT cancelled
+    block2.cancel() // Second block IS cancelled
+    }
+
+    */
     public func cancel() {
         dispatch_block_cancel(block)
     }
@@ -466,14 +466,14 @@ public struct Async {
     /**
      Convenience function to call `dispatch_block_wait()` on the encapsulated block.
      Waits for the current block to finish, on any given thread.
-     
+
      - parameters:
-        - seconds: Max seconds to wait for block to finish. If value is 0.0, it uses DISPATCH_TIME_FOREVER. Default value is 0.
-     
+     - seconds: Max seconds to wait for block to finish. If value is 0.0, it uses DISPATCH_TIME_FOREVER. Default value is 0.
+
      - SeeAlso: dispatch_block_wait, DISPATCH_TIME_FOREVER
      */
-    public func wait(seconds seconds: Double = 0.0) {
-        if seconds != 0.0 {
+    public func wait(seconds seconds: Double! = nil) {
+        if seconds != nil {
             let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
             let time = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
             dispatch_block_wait(block, time)
@@ -488,9 +488,9 @@ public struct Async {
     Convenience for `chainNow()` or `chainAfter()` depending on if the parameter `seconds` is passed or nil.
 
     - parameters:
-        - seconds: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
+    - seconds: After how many seconds the block should be run.
+    - block: The block that is to be passed to be run on the `queue`
+    - queue: The queue on which the `block` is run.
 
     - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished + any given amount of seconds.
     */
@@ -505,13 +505,13 @@ public struct Async {
      Convenience for `dispatch_block_notify()` to
 
      - parameters:
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished.
-     
+
      - SeeAlso: dispatch_block_notify, dispatch_block_create
-    */
+     */
     private func chainNow(block chainingBlock: dispatch_block_t, queue: dispatch_queue_t) -> Async {
         // See Async.async() for comments
         let _chainingBlock = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, chainingBlock)
@@ -524,12 +524,12 @@ public struct Async {
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-        - seconds: After how many seconds the block should be run.
-        - block: The block that is to be passed to be run on the `queue`
-        - queue: The queue on which the `block` is run.
+     - seconds: After how many seconds the block should be run.
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished + the given amount of seconds.
-    */
+     */
     private func chainAfter(seconds: Double, block chainingBlock: dispatch_block_t, queue: dispatch_queue_t) -> Async {
         // Create a new block (Qos Class) from block to allow adding a notification to it later (see Async)
         // Create block with the "inherit" type
@@ -558,17 +558,17 @@ public struct Async {
 /**
 `Apply` is an empty struct with convenience static functions to parallelize a for-loop, as provided by `dispatch_apply`.
 
-    Apply.background(100) { i in
-        // Calls blocks in parallel
-    }
+Apply.background(100) { i in
+// Calls blocks in parallel
+}
 
 `Apply` runs a block multiple times, before returning. If you want run the block asynchronously from the current thread, wrap it in an `Async` block:
 
-    Async.background {
-        Apply.background(100) { i in
-            // Calls blocks in parallel asynchronously
-        }
-    }
+Async.background {
+Apply.background(100) { i in
+// Calls blocks in parallel asynchronously
+}
+}
 
 - SeeAlso: Grand Central Dispatch, dispatch_apply
 */
@@ -578,8 +578,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE. The block is being passed an index parameter.
 
      - parameters:
-        - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-        - block: The block that is to be passed to be run on a .
+     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+     - block: The block that is to be passed to be run on a .
      */
     public static func userInteractive(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.userInteractiveQueue(), block)
@@ -589,8 +589,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_USER_INITIATED. The block is being passed an index parameter.
 
      - parameters:
-        - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-        - block: The block that is to be passed to be run on a .
+     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+     - block: The block that is to be passed to be run on a .
      */
     public static func userInitiated(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.userInitiatedQueue(), block)
@@ -600,8 +600,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_UTILITY. The block is being passed an index parameter.
 
      - parameters:
-        - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-        - block: The block that is to be passed to be run on a .
+     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+     - block: The block that is to be passed to be run on a .
      */
     public static func utility(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.utilityQueue(), block)
@@ -611,8 +611,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_BACKGROUND. The block is being passed an index parameter.
 
      - parameters:
-        - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-        - block: The block that is to be passed to be run on a .
+     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+     - block: The block that is to be passed to be run on a .
      */
     public static func background(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.backgroundQueue(), block)
@@ -622,12 +622,192 @@ public struct Apply {
      Block is run any given amount of times on a custom queue. The block is being passed an index parameter.
 
      - parameters:
-        - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-        - block: The block that is to be passed to be run on a .
+     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+     - block: The block that is to be passed to be run on a .
      */
     public static func customQueue(iterations: Int, queue: dispatch_queue_t, block: Int -> ()) {
         dispatch_apply(iterations, queue, block)
     }
+}
+
+
+// MARK: - AsyncGroup – Struct
+
+/**
+The **AsyncGroup** struct facilitates working with groups of asynchronous blocks. Handles a internally `dispatch_group_t`.
+
+Multiple dispatch blocks with GCD:
+
+let group = AsyncGroup()
+group.background {
+    // Run on background queue
+}
+group.utility {
+    // Run on untility queue, after the previous block
+}
+group.wait()
+
+All moderns queue classes:
+
+group.main {}
+group.userInteractive {}
+group.userInitiated {}
+group.utility {}
+group.background {}
+
+Custom queues:
+
+let customQueue = dispatch_queue_create("Label",
+DISPATCH_QUEUE_CONCURRENT)
+group.customQueue(customQueue) {}
+
+Wait for group to finish:
+
+let group = AsyncGroup()
+group.background {
+    // Do stuff
+}
+group.background {
+    // Do other stuff in parallel
+}
+// Wait for both to finish
+group.wait()
+// Do rest of stuff
+
+- SeeAlso: Grand Central Dispatch
+*/
+public struct AsyncGroup {
+
+    // MARK: - Private properties and init
+
+    /**
+    Private property to hold internally on to a `dispatch_group_t`
+    */
+    var group: dispatch_group_t
+
+    /**
+     Private init that takes a `dispatch_group_t`
+     */
+    init() {
+        group = dispatch_group_create()
+    }
+
+
+    /**
+     Convenience for `dispatch_group_async()`
+
+     - parameters:
+     - block: The block that is to be passed to be run on the `queue`
+     - queue: The queue on which the `block` is run.
+
+     - SeeAlso: dispatch_group_async, dispatch_group_create
+     */
+    private func async(block block: dispatch_block_t, queue: dispatch_queue_t) {
+        dispatch_group_async(group, queue, block)
+    }
+
+    /**
+     Convenience for `dispatch_group_enter()`. Used to add custom blocks to the current group.
+
+     - SeeAlso: dispatch_group_enter, dispatch_group_leave
+     */
+    public func enter() {
+        dispatch_group_enter(group)
+    }
+
+    /**
+     Convenience for `dispatch_group_leave()`. Used to flag a custom added block is complete.
+
+     - SeeAlso: dispatch_group_enter, dispatch_group_leave
+     */
+    public func leave() {
+        dispatch_group_leave(group)
+    }
+
+
+    // MARK: - Instance methods
+
+    /**
+    Sends the a block to be run asynchronously on the main thread, in the current group.
+
+    - parameters:
+    - block: The block that is to be passed to be run on the main queue
+    */
+    public func main(block: dispatch_block_t) {
+        async(block: block, queue: GCD.mainQueue())
+    }
+
+    /**
+     Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE, in the current group.
+
+     - parameters:
+     - block: The block that is to be passed to be run on the queue
+     */
+    public func userInteractive(block: dispatch_block_t) {
+        async(block: block, queue: GCD.userInteractiveQueue())
+    }
+
+    /**
+     Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED, in the current group.
+
+     - parameters:
+     - block: The block that is to be passed to be run on the queue
+     */
+    public func userInitiated(block: dispatch_block_t) {
+        async(block: block, queue: GCD.userInitiatedQueue())
+    }
+
+    /**
+     Sends the a block to be run asynchronously on a queue with a quality of service of 
+        QOS_CLASS_UTILITY, in the current block.
+
+     - parameters:
+     - block: The block that is to be passed to be run on the queue
+     */
+    public func utility(block: dispatch_block_t) {
+        async(block: block, queue: GCD.utilityQueue())
+    }
+
+    /**
+     Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND, in the current block.
+
+     - parameters:
+     - block: The block that is to be passed to be run on the queue
+     */
+    public func background(block: dispatch_block_t) {
+        async(block: block, queue: GCD.backgroundQueue())
+    }
+
+    /**
+     Sends the a block to be run asynchronously on a custom queue, in the current group.
+
+     - parameters:
+     - queue: Custom queue where the block will be run.
+     - block: The block that is to be passed to be run on the queue
+     */
+    public func customQueue(queue: dispatch_queue_t, block: dispatch_block_t) {
+        async(block: block, queue: queue)
+    }
+
+    /**
+     Convenience function to call `dispatch_group_wait()` on the encapsulated block.
+     Waits for the current group to finish, on any given thread.
+
+     - parameters:
+     - seconds: Max seconds to wait for block to finish. If value is nil, it uses DISPATCH_TIME_FOREVER. Default value is nil.
+
+     - SeeAlso: dispatch_group_wait, DISPATCH_TIME_FOREVER
+     */
+    public func wait(seconds seconds: Double! = nil) {
+        if seconds != nil {
+            let nanoSeconds = Int64(seconds * Double(NSEC_PER_SEC))
+            let time = dispatch_time(DISPATCH_TIME_NOW, nanoSeconds)
+            dispatch_group_wait(group, time)
+        } else {
+            dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
+        }
+    }
+
 }
 
 
@@ -640,7 +820,7 @@ public extension qos_class_t {
 
     /**
      Description of the `qos_class_t`. E.g. "Main", "User Interactive", etc. for the given Quality of Service class.
-    */
+     */
     var description: String {
         get {
             switch self {

--- a/Source/Async.swift
+++ b/Source/Async.swift
@@ -111,54 +111,53 @@ The **Async** struct is the main part of the Async.framework. Handles a internal
 
 Chainable dispatch blocks with GCD:
 
-Async.background {
-// Run on background queue
-}.main {
-// Run on main queue, after the previous block
-}
+    Async.background {
+    // Run on background queue
+    }.main {
+    // Run on main queue, after the previous block
+    }
 
 All moderns queue classes:
 
-Async.main {}
-Async.userInteractive {}
-Async.userInitiated {}
-Async.utility {}
-Async.background {}
+    Async.main {}
+    Async.userInteractive {}
+    Async.userInitiated {}
+    Async.utility {}
+    Async.background {}
 
 Custom queues:
 
-let customQueue = dispatch_queue_create("Label",
-DISPATCH_QUEUE_CONCURRENT)
-Async.customQueue(customQueue) {}
+    let customQueue = dispatch_queue_create("Label", DISPATCH_QUEUE_CONCURRENT)
+    Async.customQueue(customQueue) {}
 
 Dispatch block after delay:
 
-let seconds = 0.5
-Async.main(after: seconds) {}
+    let seconds = 0.5
+    Async.main(after: seconds) {}
 
 Cancel blocks not yet dispatched
 
-let block1 = Async.background {
-// Some work
-}
-let block2 = block1.background {
-// Some other work
-}
-Async.main {
-// Cancel async to allow block1 to begin
-block1.cancel() // First block is NOT cancelled
-block2.cancel() // Second block IS cancelled
-}
+    let block1 = Async.background {
+        // Some work
+    }
+    let block2 = block1.background {
+        // Some other work
+    }
+    Async.main {
+        // Cancel async to allow block1 to begin
+        block1.cancel() // First block is NOT cancelled
+        block2.cancel() // Second block IS cancelled
+    }
 
 Wait for block to finish:
 
-let block = Async.background {
-// Do stuff
-}
-// Do other stuff
-// Wait for "Do stuff" to finish
-block.wait()
-// Do rest of stuff
+    let block = Async.background {
+        // Do stuff
+    }
+    // Do other stuff
+    // Wait for "Do stuff" to finish
+    block.wait()
+    // Do rest of stuff
 
 - SeeAlso: Grand Central Dispatch
 */
@@ -168,7 +167,7 @@ public struct Async {
     // MARK: - Private properties and init
 
     /**
-    Private property to hold internally on to a `dispatch_block_t`
+     Private property to hold internally on to a `dispatch_block_t`
     */
     private let block: dispatch_block_t
 
@@ -186,8 +185,8 @@ public struct Async {
     Sends the a block to be run asynchronously on the main thread.
 
     - parameters:
-    - after: After how many seconds the block should be run.
-    - block: The block that is to be passed to be run on the main queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the main queue
 
     - returns: An `Async` struct
 
@@ -201,8 +200,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -216,8 +215,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -231,8 +230,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_UTILITY.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on queue
 
      - returns: An `Async` struct
 
@@ -246,8 +245,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -261,8 +260,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a custom queue.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -279,9 +278,9 @@ public struct Async {
     Convenience for `asyncNow()` or `asyncAfter()` depending on if the parameter `seconds` is passed or nil.
 
     - parameters:
-    - seconds: After how many seconds the block should be run.
-    - block: The block that is to be passed to be run on the `queue`
-    - queue: The queue on which the `block` is run.
+        - seconds: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the `queue`
+        - queue: The queue on which the `block` is run.
 
     - returns: An `Async` struct which encapsulates the `dispatch_block_t`
     */
@@ -296,8 +295,8 @@ public struct Async {
      Convenience for dispatch_async(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`
      */
@@ -315,9 +314,9 @@ public struct Async {
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-     - seconds: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - seconds: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`
      */
@@ -331,9 +330,9 @@ public struct Async {
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-     - time: The specific time (`dispatch_time_t`) the block should be run.
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - time: The specific time (`dispatch_time_t`) the block should be run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`
      */
@@ -351,8 +350,8 @@ public struct Async {
     Sends the a block to be run asynchronously on the main thread, after the current block has finished.
 
     - parameters:
-    - after: After how many seconds the block should be run.
-    - block: The block that is to be passed to be run on the main queue
+        - after: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the main queue
 
     - returns: An `Async` struct
 
@@ -366,8 +365,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE, after the current block has finished.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+         - after: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -381,8 +380,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED, after the current block has finished.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+         - after: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -396,8 +395,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_UTILITY, after the current block has finished.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+         - after: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -411,8 +410,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND, after the current block has finished.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+         - after: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -426,8 +425,8 @@ public struct Async {
      Sends the a block to be run asynchronously on a custom queue, after the current block has finished.
 
      - parameters:
-     - after: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the queue
+         - after: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the queue
 
      - returns: An `Async` struct
 
@@ -445,17 +444,17 @@ public struct Async {
 
     Usage:
 
-    let block1 = Async.background {
-    // Some work
-    }
-    let block2 = block1.background {
-    // Some other work
-    }
-    Async.main {
-    // Cancel async to allow block1 to begin
-    block1.cancel() // First block is NOT cancelled
-    block2.cancel() // Second block IS cancelled
-    }
+        let block1 = Async.background {
+            // Some work
+        }
+        let block2 = block1.background {
+            // Some other work
+        }
+        Async.main {
+            // Cancel async to allow block1 to begin
+            block1.cancel() // First block is NOT cancelled
+            block2.cancel() // Second block IS cancelled
+        }
 
     */
     public func cancel() {
@@ -468,7 +467,7 @@ public struct Async {
      Waits for the current block to finish, on any given thread.
 
      - parameters:
-     - seconds: Max seconds to wait for block to finish. If value is 0.0, it uses DISPATCH_TIME_FOREVER. Default value is 0.
+        - seconds: Max seconds to wait for block to finish. If value is 0.0, it uses DISPATCH_TIME_FOREVER. Default value is 0.
 
      - SeeAlso: dispatch_block_wait, DISPATCH_TIME_FOREVER
      */
@@ -488,9 +487,9 @@ public struct Async {
     Convenience for `chainNow()` or `chainAfter()` depending on if the parameter `seconds` is passed or nil.
 
     - parameters:
-    - seconds: After how many seconds the block should be run.
-    - block: The block that is to be passed to be run on the `queue`
-    - queue: The queue on which the `block` is run.
+        - seconds: After how many seconds the block should be run.
+        - block: The block that is to be passed to be run on the `queue`
+        - queue: The queue on which the `block` is run.
 
     - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished + any given amount of seconds.
     */
@@ -505,8 +504,8 @@ public struct Async {
      Convenience for `dispatch_block_notify()` to
 
      - parameters:
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished.
 
@@ -524,9 +523,9 @@ public struct Async {
      Convenience for dispatch_after(). Encapsulates the block in a "true" GCD block using DISPATCH_BLOCK_INHERIT_QOS_CLASS.
 
      - parameters:
-     - seconds: After how many seconds the block should be run.
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - seconds: After how many seconds the block should be run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - returns: An `Async` struct which encapsulates the `dispatch_block_t`, which is called when the current block has finished + the given amount of seconds.
      */
@@ -558,17 +557,17 @@ public struct Async {
 /**
 `Apply` is an empty struct with convenience static functions to parallelize a for-loop, as provided by `dispatch_apply`.
 
-Apply.background(100) { i in
-// Calls blocks in parallel
-}
+    Apply.background(100) { i in
+        // Calls blocks in parallel
+    }
 
 `Apply` runs a block multiple times, before returning. If you want run the block asynchronously from the current thread, wrap it in an `Async` block:
 
-Async.background {
-Apply.background(100) { i in
-// Calls blocks in parallel asynchronously
-}
-}
+    Async.background {
+        Apply.background(100) { i in
+            // Calls blocks in parallel asynchronously
+        }
+    }
 
 - SeeAlso: Grand Central Dispatch, dispatch_apply
 */
@@ -578,8 +577,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE. The block is being passed an index parameter.
 
      - parameters:
-     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-     - block: The block that is to be passed to be run on a .
+         - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+         - block: The block that is to be passed to be run on a .
      */
     public static func userInteractive(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.userInteractiveQueue(), block)
@@ -589,8 +588,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_USER_INITIATED. The block is being passed an index parameter.
 
      - parameters:
-     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-     - block: The block that is to be passed to be run on a .
+         - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+         - block: The block that is to be passed to be run on a .
      */
     public static func userInitiated(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.userInitiatedQueue(), block)
@@ -600,8 +599,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_UTILITY. The block is being passed an index parameter.
 
      - parameters:
-     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-     - block: The block that is to be passed to be run on a .
+         - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+         - block: The block that is to be passed to be run on a .
      */
     public static func utility(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.utilityQueue(), block)
@@ -611,8 +610,8 @@ public struct Apply {
      Block is run any given amount of times on a queue with a quality of service of QOS_CLASS_BACKGROUND. The block is being passed an index parameter.
 
      - parameters:
-     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-     - block: The block that is to be passed to be run on a .
+         - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+         - block: The block that is to be passed to be run on a .
      */
     public static func background(iterations: Int, block: Int -> ()) {
         dispatch_apply(iterations, GCD.backgroundQueue(), block)
@@ -622,8 +621,8 @@ public struct Apply {
      Block is run any given amount of times on a custom queue. The block is being passed an index parameter.
 
      - parameters:
-     - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
-     - block: The block that is to be passed to be run on a .
+         - iterations: How many times the block should be run. Index provided to block goes from `0..<iterations`
+         - block: The block that is to be passed to be run on a .
      */
     public static func customQueue(iterations: Int, queue: dispatch_queue_t, block: Int -> ()) {
         dispatch_apply(iterations, queue, block)
@@ -638,41 +637,40 @@ The **AsyncGroup** struct facilitates working with groups of asynchronous blocks
 
 Multiple dispatch blocks with GCD:
 
-let group = AsyncGroup()
-group.background {
-    // Run on background queue
-}
-group.utility {
-    // Run on untility queue, after the previous block
-}
-group.wait()
+    let group = AsyncGroup()
+    group.background {
+        // Run on background queue
+    }
+    group.utility {
+        // Run on untility queue, after the previous block
+    }
+    group.wait()
 
 All moderns queue classes:
 
-group.main {}
-group.userInteractive {}
-group.userInitiated {}
-group.utility {}
-group.background {}
+    group.main {}
+    group.userInteractive {}
+    group.userInitiated {}
+    group.utility {}
+    group.background {}
 
 Custom queues:
 
-let customQueue = dispatch_queue_create("Label",
-DISPATCH_QUEUE_CONCURRENT)
-group.customQueue(customQueue) {}
+    let customQueue = dispatch_queue_create("Label", DISPATCH_QUEUE_CONCURRENT)
+    group.customQueue(customQueue) {}
 
 Wait for group to finish:
 
-let group = AsyncGroup()
-group.background {
-    // Do stuff
-}
-group.background {
-    // Do other stuff in parallel
-}
-// Wait for both to finish
-group.wait()
-// Do rest of stuff
+    let group = AsyncGroup()
+    group.background {
+        // Do stuff
+    }
+    group.background {
+        // Do other stuff in parallel
+    }
+    // Wait for both to finish
+    group.wait()
+    // Do rest of stuff
 
 - SeeAlso: Grand Central Dispatch
 */
@@ -681,7 +679,7 @@ public struct AsyncGroup {
     // MARK: - Private properties and init
 
     /**
-    Private property to hold internally on to a `dispatch_group_t`
+     Private property to hold internally on to a `dispatch_group_t`
     */
     var group: dispatch_group_t
 
@@ -697,8 +695,8 @@ public struct AsyncGroup {
      Convenience for `dispatch_group_async()`
 
      - parameters:
-     - block: The block that is to be passed to be run on the `queue`
-     - queue: The queue on which the `block` is run.
+         - block: The block that is to be passed to be run on the `queue`
+         - queue: The queue on which the `block` is run.
 
      - SeeAlso: dispatch_group_async, dispatch_group_create
      */
@@ -731,7 +729,7 @@ public struct AsyncGroup {
     Sends the a block to be run asynchronously on the main thread, in the current group.
 
     - parameters:
-    - block: The block that is to be passed to be run on the main queue
+        - block: The block that is to be passed to be run on the main queue
     */
     public func main(block: dispatch_block_t) {
         async(block: block, queue: GCD.mainQueue())
@@ -741,7 +739,7 @@ public struct AsyncGroup {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INTERACTIVE, in the current group.
 
      - parameters:
-     - block: The block that is to be passed to be run on the queue
+        - block: The block that is to be passed to be run on the queue
      */
     public func userInteractive(block: dispatch_block_t) {
         async(block: block, queue: GCD.userInteractiveQueue())
@@ -751,7 +749,7 @@ public struct AsyncGroup {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_USER_INITIATED, in the current group.
 
      - parameters:
-     - block: The block that is to be passed to be run on the queue
+        - block: The block that is to be passed to be run on the queue
      */
     public func userInitiated(block: dispatch_block_t) {
         async(block: block, queue: GCD.userInitiatedQueue())
@@ -762,7 +760,7 @@ public struct AsyncGroup {
         QOS_CLASS_UTILITY, in the current block.
 
      - parameters:
-     - block: The block that is to be passed to be run on the queue
+        - block: The block that is to be passed to be run on the queue
      */
     public func utility(block: dispatch_block_t) {
         async(block: block, queue: GCD.utilityQueue())
@@ -772,7 +770,7 @@ public struct AsyncGroup {
      Sends the a block to be run asynchronously on a queue with a quality of service of QOS_CLASS_BACKGROUND, in the current block.
 
      - parameters:
-     - block: The block that is to be passed to be run on the queue
+         - block: The block that is to be passed to be run on the queue
      */
     public func background(block: dispatch_block_t) {
         async(block: block, queue: GCD.backgroundQueue())
@@ -782,8 +780,8 @@ public struct AsyncGroup {
      Sends the a block to be run asynchronously on a custom queue, in the current group.
 
      - parameters:
-     - queue: Custom queue where the block will be run.
-     - block: The block that is to be passed to be run on the queue
+         - queue: Custom queue where the block will be run.
+         - block: The block that is to be passed to be run on the queue
      */
     public func customQueue(queue: dispatch_queue_t, block: dispatch_block_t) {
         async(block: block, queue: queue)
@@ -794,7 +792,7 @@ public struct AsyncGroup {
      Waits for the current group to finish, on any given thread.
 
      - parameters:
-     - seconds: Max seconds to wait for block to finish. If value is nil, it uses DISPATCH_TIME_FOREVER. Default value is nil.
+         - seconds: Max seconds to wait for block to finish. If value is nil, it uses DISPATCH_TIME_FOREVER. Default value is nil.
 
      - SeeAlso: dispatch_group_wait, DISPATCH_TIME_FOREVER
      */


### PR DESCRIPTION
### AsyncGroup
**AsyncGroup** facilitates working with groups of asynchronous blocks.

Multiple dispatch blocks with GCD:
```swift
let group = AsyncGroup()
group.background {
    // Run on background queue
}
group.utility {
    // Run on utility queue, in parallel to the previous block
}
group.wait()
```
All modern queue classes:
```swift
group.main {}
group.userInteractive {}
group.userInitiated {}
group.utility {}
group.background {}
```
Custom queues:
```swift
let customQueue = dispatch_queue_create("Label", DISPATCH_QUEUE_CONCURRENT)
group.customQueue(customQueue) {}
```
Wait for group to finish:
```swift
let group = AsyncGroup()
group.background {
    // Do stuff
}
group.background {
    // Do other stuff in parallel
}
// Wait for both to finish
group.wait()
// Do rest of stuff
```
Custom asynchronous operations:
```swift
let group = AsyncGroup()
group.enter()
dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
    // Do stuff
    group.leave()
}
group.enter()
dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
    // Do other stuff in parallel
    group.leave()
}
// Wait for both to finish
group.wait()
// Do rest of stuff
```
