### PR TITLE
Add notify method to AsyncGroup

### DIFF
--- a/AsyncPodsExample/AsyncExample OS X/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample OS X/ViewController.swift
@@ -101,6 +101,21 @@ class ViewController: NSViewController {
 			block2.cancel() // Second block _is_ cancelled
 		}
 		*/
+        
+        //AsyncGroup
+        /*
+        let group = AsyncGroup()
+        group.background{
+        print("A: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+        sleep(5)
+        }
+        group.background{
+        print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+        sleep(5)
+        }
+        group.notify{
+        print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
+        }*/
 	}
 }
 

--- a/AsyncPodsExample/AsyncExample OS X/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample OS X/ViewController.swift
@@ -113,7 +113,7 @@ class ViewController: NSViewController {
         print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
         sleep(5)
         }
-        group.notify{
+        group.notifyOnMainQueue{
         print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
         }*/
 	}

--- a/AsyncPodsExample/AsyncExample iOS/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample iOS/ViewController.swift
@@ -101,6 +101,21 @@ class ViewController: UIViewController {
 			block2.cancel() // Second block _is_ cancelled
 		}
 		*/
+        
+        //AsyncGroup
+        /*
+        let group = AsyncGroup()
+        group.background{
+            print("A: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            sleep(5)
+        }
+        group.background{
+            print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+            sleep(5)
+        }
+        group.notify{
+            print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
+        }*/
 	}
 }
 

--- a/AsyncPodsExample/AsyncExample iOS/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample iOS/ViewController.swift
@@ -113,7 +113,7 @@ class ViewController: UIViewController {
             print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
             sleep(5)
         }
-        group.notify{
+        group.notifyOnMainQueue{
             print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
         }*/
 	}

--- a/AsyncPodsExample/AsyncExample tvOS/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample tvOS/ViewController.swift
@@ -101,6 +101,21 @@ class ViewController: UIViewController {
         block2.cancel() // Second block _is_ cancelled
         }
         */
+        
+        //AsyncGroup
+        /*
+        let group = AsyncGroup()
+        group.background{
+        print("A: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+        sleep(5)
+        }
+        group.background{
+        print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
+        sleep(5)
+        }
+        group.notify{
+        print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
+        }*/
     }
 }
 

--- a/AsyncPodsExample/AsyncExample tvOS/ViewController.swift
+++ b/AsyncPodsExample/AsyncExample tvOS/ViewController.swift
@@ -113,7 +113,7 @@ class ViewController: UIViewController {
         print("B: This is run on the \(qos_class_self().description) (expected \(QOS_CLASS_BACKGROUND.description))")
         sleep(5)
         }
-        group.notify{
+        group.notifyOnMainQueue{
         print("This is run on the \(qos_class_self().description) (expected \(qos_class_main().description))")
         }*/
     }

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ group.background {
 group.utility {
     // Run on utility queue, in parallel to the previous block
 }
-group.wait()
 ```
 All modern queue classes:
 ```swift
@@ -228,7 +227,8 @@ group.notify {
 }
 //we can specify the custom queue where the block will be run
 /*
- group.notify(customQueue) {
+let customQueue = dispatch_queue_create("customQueue", DISPATCH_QUEUE_CONCURRENT)
+group.notify(customQueue) {
  	print("Both asynchronous blocks are complete on custom queue")
 }
 */

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 Syntactic sugar in Swift for asynchronous dispatches in Grand Central Dispatch ([GCD](https://developer.apple.com/library/prerelease/ios/documentation/Performance/Reference/GCD_libdispatch_Ref/index.html))
 
 **Async** sugar looks like this:
+
 ```swift
 Async.background {
 	print("This is run on the background queue")
@@ -15,6 +16,7 @@ Async.background {
 ```
 
 Instead of the familiar syntax for GCD:
+
 ```swift
 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), {
 	print("This is run on the background queue")
@@ -26,6 +28,7 @@ dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0),
 ```
 
 **AsyncGroup** sugar looks like this:
+
 ```swift
 let group = AsyncGroup()
 group.background {
@@ -34,7 +37,7 @@ group.background {
 group.background {
     print("This is also run on the background queue in parallel")
 }
-group.notify {
+group.notifyOnMainQueue {
 	print("Both asynchronous blocks are complete")
 }
 ```
@@ -56,6 +59,7 @@ github "duemunk/Async"
 
 ### Things you can do
 Supports the modern queue classes:
+
 ```swift
 Async.main {}
 Async.userInteractive {}
@@ -65,6 +69,7 @@ Async.background {}
 ```
 
 Chain as many blocks as you want:
+
 ```swift
 Async.userInitiated {
 	// 1
@@ -78,6 +83,7 @@ Async.userInitiated {
 ```
 
 Store reference for later chaining:
+
 ```swift
 let backgroundBlock = Async.background {
 	print("This is run on the background queue")
@@ -92,6 +98,7 @@ backgroundBlock.main {
 ```
 
 Custom queues:
+
 ```swift
 let customQueue = dispatch_queue_create("CustomQueueLabel", DISPATCH_QUEUE_CONCURRENT)
 let otherCustomQueue = dispatch_queue_create("OtherCustomQueueLabel", DISPATCH_QUEUE_CONCURRENT)
@@ -103,6 +110,7 @@ Async.customQueue(customQueue) {
 ```
 
 Dispatch block after delay:
+
 ```swift
 let seconds = 0.5
 Async.main(after: seconds) {
@@ -113,6 +121,7 @@ Async.main(after: seconds) {
 ```
 
 Cancel blocks that aren't already dispatched:
+
 ```swift
 // Cancel blocks not yet dispatched
 let block1 = Async.background {
@@ -144,6 +153,7 @@ block.wait()
 
 ### How does it work
 The way it work is by using the new notification API for GCD introduced in OS X 10.10 and iOS 8. Each chaining block is called when the previous queue has finished.
+
 ```swift
 let previousBlock = {}
 let chainingBlock = {}
@@ -167,6 +177,7 @@ The ```dispatch_block_t``` can't be extended. Workaround used: Wrap ```dispatch_
 
 ### Apply
 There is also a wrapper for [`dispatch_apply()`](https://developer.apple.com/library/mac/documentation/Performance/Reference/GCD_libdispatch_Ref/index.html#//apple_ref/c/func/dispatch_apply)  for quick parallelisation of a `for` loop.
+
 ```swift
 Apply.background(100) { i in
 	// Do stuff e.g. print(i)
@@ -178,6 +189,7 @@ Note that this function returns after the block has been run all 100 times i.e. 
 **AsyncGroup** facilitates working with groups of asynchronous blocks.
 
 Multiple dispatch blocks with GCD:
+
 ```swift
 let group = AsyncGroup()
 group.background {
@@ -188,6 +200,7 @@ group.utility {
 }
 ```
 All modern queue classes:
+
 ```swift
 group.main {}
 group.userInteractive {}
@@ -196,11 +209,14 @@ group.utility {}
 group.background {}
 ```
 Custom queues:
+
 ```swift
 let customQueue = dispatch_queue_create("Label", DISPATCH_QUEUE_CONCURRENT)
 group.customQueue(customQueue) {}
 ```
+
 Wait for group to finish:
+
 ```swift
 let group = AsyncGroup()
 group.background {
@@ -213,7 +229,8 @@ group.background {
 group.wait()
 // Do rest of stuff
 ```
-Non-blocking alternative
+Non-blocking alternative for group to finish:
+
 ```swift
 let group = AsyncGroup()
 group.background {
@@ -222,18 +239,31 @@ group.background {
 group.background {
     // Do other stuff in parallel
 }
-group.notify {
+group.notifyOnMainQueue {
 	print("Both asynchronous blocks are complete on main queue")
 }
-//we can specify the custom queue where the block will be run
-/*
+```
+
+All modern queue classes:
+
+```swift
+group.notifyOnMainQueue {}
+group.notifyOnUserInteractiveQueue {}
+group.notifyOnUserInitiatedQueue {}
+group.notifyOnUtilityQueue {}
+group.notifyOnBackgroundQueue {}
+```
+
+Custom queues:
+
+```swift
 let customQueue = dispatch_queue_create("customQueue", DISPATCH_QUEUE_CONCURRENT)
-group.notify(customQueue) {
+group.notifyOnQueue(customQueue) {
  	print("Both asynchronous blocks are complete on custom queue")
 }
-*/
 ```
 Custom asynchronous operations:
+
 ```swift
 let group = AsyncGroup()
 group.enter()
@@ -247,6 +277,7 @@ dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
     group.leave()
 }
 // Wait for both to finish
+// You also can use the Non-blocking alternative
 group.wait()
 // Do rest of stuff
 ```
@@ -272,3 +303,4 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ group.background {
 group.background {
     print("This is also run on the background queue in parallel")
 }
-group.wait()
-print("Both asynchronous blocks are complete")
+group.notify {
+	print("Both asynchronous blocks are complete")
+}
 ```
 
 ### Install
@@ -212,6 +213,25 @@ group.background {
 // Wait for both to finish
 group.wait()
 // Do rest of stuff
+```
+Non-blocking alternative
+```swift
+let group = AsyncGroup()
+group.background {
+    // Do stuff
+}
+group.background {
+    // Do other stuff in parallel
+}
+group.notify {
+	print("Both asynchronous blocks are complete on main queue")
+}
+//we can specify the custom queue where the block will be run
+/*
+ group.notify(customQueue) {
+ 	print("Both asynchronous blocks are complete on custom queue")
+}
+*/
 ```
 Custom asynchronous operations:
 ```swift

--- a/Source/Async.swift
+++ b/Source/Async.swift
@@ -805,7 +805,18 @@ public struct AsyncGroup {
             dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
         }
     }
-
+    
+    /**
+     Sends the a block to be run on a custom queue once all blocks associated
+     with the group have completed
+     
+     - parameter queue: Custom queue where the block will be run.
+     - parameter block: The block that is to be passed to be run on the queue
+     */
+    public func notify(queue: dispatch_queue_t = GCD.mainQueue(), block: dispatch_block_t){
+        dispatch_group_notify(group, queue, block)
+    }
+    
 }
 
 

--- a/Source/Async.swift
+++ b/Source/Async.swift
@@ -810,8 +810,8 @@ public struct AsyncGroup {
      Sends the a block to be run on a custom queue once all blocks associated
      with the group have completed
      
-     - parameter queue: Custom queue where the block will be run.
-     - parameter block: The block that is to be passed to be run on the queue
+     - parameter queue: Custom queue where the block will be run. Default value is main queue.
+     - parameter block: The block that is to be passed to be run on the queue.
      */
     public func notify(queue: dispatch_queue_t = GCD.mainQueue(), block: dispatch_block_t){
         dispatch_group_notify(group, queue, block)

--- a/Source/Async.swift
+++ b/Source/Async.swift
@@ -810,11 +810,61 @@ public struct AsyncGroup {
      Sends the a block to be run on a custom queue once all blocks associated
      with the group have completed
      
-     - parameter queue: Custom queue where the block will be run. Default value is main queue.
+     - parameter queue: Custom queue where the block will be run.
      - parameter block: The block that is to be passed to be run on the queue.
      */
-    public func notify(queue: dispatch_queue_t = GCD.mainQueue(), block: dispatch_block_t){
+    public func notifyOnQueue(queue: dispatch_queue_t, block: dispatch_block_t) {
         dispatch_group_notify(group, queue, block)
+    }
+    
+    /**
+     Sends the a block to be run on the main queue once all blocks associated
+     with the group have completed
+     
+     - parameter block: The block that is to be passed to be run on the queue.
+     */
+    public func notifyOnMainQueue(block: dispatch_block_t) {
+        notifyOnQueue(GCD.mainQueue(), block: block)
+    }
+    
+    /**
+     Sends the a block to be run on the userInteractiveQueue queue once all blocks associated
+     with the group have completed
+     
+     - parameter block: The block that is to be passed to be run on the queue.
+     */
+    public func notifyOnUserInteractiveQueue(block: dispatch_block_t) {
+        notifyOnQueue(GCD.userInteractiveQueue(), block: block)
+    }
+    
+    /**
+     Sends the a block to be run on the userInitiated queue once all blocks associated
+     with the group have completed
+     
+     - parameter block: The block that is to be passed to be run on the queue.
+     */
+    public func notifyOnUserInitiatedQueue(block: dispatch_block_t) {
+        notifyOnQueue(GCD.userInitiatedQueue(), block: block)
+    }
+    
+    /**
+     Sends the a block to be run on the utility queue once all blocks associated
+     with the group have completed
+     
+     - parameter block: The block that is to be passed to be run on the queue.
+     */
+    public func notifyOnUtilityQueue(block: dispatch_block_t) {
+        notifyOnQueue(GCD.utilityQueue(), block: block)
+    }
+    
+    /**
+     Sends the a block to be run on the background queue once all blocks associated
+     with the group have completed
+     
+     - parameter block: The block that is to be passed to be run on the queue.
+     */
+    public func notifyOnBackgroundQueue(block: dispatch_block_t) {
+        notifyOnQueue(GCD.backgroundQueue(), block: block)
     }
     
 }


### PR DESCRIPTION
support

``` swift
let group = AsyncGroup()
group.background {
print("This is run on the background queue")
}
group.background {
print("This is also run on the background queue in parallel")
}
group.notify {
print("Both asynchronous blocks are complete")
}
```
