### PR TITLE
setting SKIP_INSTALL to YES so it can be built properly as a subproject

### DIFF
--- a/Async.xcodeproj/project.pbxproj
+++ b/Async.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Async;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -343,6 +344,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = Async;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};


### PR DESCRIPTION
When including Async as a subproject and archiving. Xcode doesn't recognise the archive as an iOS app because this flag is set to NO.