### PR TITLE
Setting ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES to NO

### DIFF
--- a/Async.xcodeproj/project.pbxproj
+++ b/Async.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1F9952281EA0FF2F0095B0F1 /* Async-Debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 			};
 			name = Debug;
 		};
@@ -233,6 +234,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1F9952291EA0FF2F0095B0F1 /* Async-Release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES seems to default to YES and causes issues when uploading to itunesconnect