### PR TITLE
Fixed Xcode 10.2 warnings

### DIFF
--- a/Sources/Async/Async.swift
+++ b/Sources/Async/Async.swift
@@ -762,6 +762,7 @@ public extension DispatchQoS.QoSClass {
             case .utility: return "Utility"
             case .background: return "Background"
             case .unspecified: return "Unspecified"
+            @unknown default: return "Unknown"
             }
         }
     }


### PR DESCRIPTION
Hello.
In this pull request I added `@unknown default:` to the implementation of `DispatchQoS.QoSClass.description`. It works fine with all supported Swift version in Xcode 10.2 (see [this link](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes/swift_5_release_notes_for_xcode_10_2) for more details about @unknown).
I added `QoSClassDescription` to unify the string constants using in `DispatchQoS.QoSClass.description` and `qos_class_t.description`.
I also removed `get` in some computed properties.